### PR TITLE
Port to simple three.js web demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore Unity meta files and temporary data
+*.meta
+
+# Ignore temporary files
+*.tmp
+
+# Ignore zipped archives
+*.zip
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# MagasteinBeta (Web)
+
+The original files in this repository were Unity C# scripts. A simple browser-based prototype has been added in the `web` directory. It uses three.js to render a small block grid and demonstrates block highlighting similar to the Unity version.
+
+To try the prototype, open `web/index.html` in a browser or run a local HTTP server in that directory.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,13 @@
+# Magastein Web Prototype
+
+This directory contains a lightweight browser-based version of the original Unity project. It uses [three.js](https://threejs.org/) to render a small grid of blocks and allows highlighting with the mouse.
+
+## Running
+Open `index.html` directly in a browser or serve the directory via a local server:
+
+```
+# if Node.js is available
+npx serve web
+```
+
+Then open the provided URL in a browser.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Magastein Web Prototype</title>
+  <style>
+    body { margin: 0; overflow: hidden; }
+  </style>
+</head>
+<body>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,60 @@
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const blocks = [];
+const gridSize = 8;
+for (let x = 0; x < gridSize; x++) {
+  for (let z = 0; z < gridSize; z++) {
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshStandardMaterial({ color: 0x666666 });
+    const cube = new THREE.Mesh(geometry, material);
+    cube.position.set(x - gridSize / 2, 0, z - gridSize / 2);
+    scene.add(cube);
+    blocks.push(cube);
+  }
+}
+
+const light = new THREE.DirectionalLight(0xffffff, 0.8);
+light.position.set(0, 10, 10);
+scene.add(light);
+
+camera.position.set(0, 5, 10);
+camera.lookAt(0, 0, 0);
+
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2();
+let highlighted = null;
+
+function onMove(event) {
+  mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+  mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+  raycaster.setFromCamera(mouse, camera);
+  const intersects = raycaster.intersectObjects(blocks);
+  if (intersects.length > 0) {
+    const obj = intersects[0].object;
+    if (highlighted && highlighted !== obj) {
+      highlighted.material.emissive.set(0x000000);
+    }
+    highlighted = obj;
+    highlighted.material.emissive.set(0x3333ff);
+  } else {
+    if (highlighted) highlighted.material.emissive.set(0x000000);
+    highlighted = null;
+  }
+}
+window.addEventListener('mousemove', onMove);
+
+function animate() {
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+}
+animate();
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});


### PR DESCRIPTION
## Summary
- add a small browser-based prototype using three.js
- document new usage in `README.md`
- ignore Unity metadata files

## Testing
- `node -v`
- `node web/main.js` *(fails: THREE is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68440e14de9c833282dcadf87f6ff7d1